### PR TITLE
chore: migrate to dart only

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,14 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
-  characters:
-    dependency: transitive
-    description:
-      name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
   collection:
     dependency: transitive
     description:
@@ -97,11 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
-  flutter:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -182,14 +169,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.15"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -301,11 +280,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
-  sky_engine:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.99"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -394,14 +368,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
-  vector_math:
-    dependency: transitive
-    description:
-      name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -452,4 +418,3 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.0.0-0 <4.0.0"
-  flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,19 +6,15 @@ repository: https://github.com/abichinger/nonogram_dart
 
 environment:
   sdk: '>=2.18.2 <4.0.0'
-  flutter: ">=1.17.0"
 
 dependencies:
   collection: ^1.17.0
   crypto: ^3.0.3
-  flutter:
-    sdk: flutter
   image: ^4.0.17
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  flutter_lints: ^2.0.0
+  test:
+  lints: ^2.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/description_test.dart
+++ b/test/description_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:nonogram_dart/nonogram_dart.dart';
 import 'package:nonogram_dart/src/description.dart' as desc;
 

--- a/test/generate_test.dart
+++ b/test/generate_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:nonogram_dart/nonogram_dart.dart';
 
 void main() {

--- a/test/line_solver_test.dart
+++ b/test/line_solver_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:nonogram_dart/nonogram_dart.dart';
 import 'package:nonogram_dart/src/description.dart' as desc;
 

--- a/test/nonogram_test.dart
+++ b/test/nonogram_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:nonogram_dart/nonogram_dart.dart';
 import 'package:nonogram_dart/src/description.dart' as desc;
 

--- a/test/solver_test.dart
+++ b/test/solver_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:nonogram_dart/src/description.dart' as desc;
 import 'package:nonogram_dart/src/nonogram.dart';
 import 'package:nonogram_dart/src/solver/solver.dart';

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:nonogram_dart/nonogram_dart.dart';
 
 void expectGrid(Grid grid, List<List<int?>> expected) {


### PR DESCRIPTION
Thanks for creating this package :) A couple of years ago, I wanted to develop such a package however never found the time!

Currently the package has a dependency on Flutter, however this can be removed and the package can be Dart only.